### PR TITLE
OPS-2706 Update Ansible version and add AWS tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
     - TAG=2.5-aws
     - TAG=2.6
     - TAG=2.6-aws
+    - TAG=2.7
+    - TAG=2.7-aws
     - TAG=latest
     - TAG=latest-aws
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN set -x \
 		else \
 			pip install --no-cache-dir "ansible>=${ANSIBLE_VERSION},<$(echo "${ANSIBLE_VERSION}+0.1" | bc)"; \
 		fi \
+	&& pip install --no-cache-dir \
+		pyaml \
 	&& apt-get remove -f -y --purge --auto-remove build-essential bc \
 	&& apt-get clean \
 	&& apt-get autoremove -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN set -x \
 		python-cffi \
 		build-essential \
 	&& if [ -z "${ANSIBLE_VERSION}" ]; then \
-			pip install ansible;\
+			pip install --no-cache-dir ansible;\
 		else \
-			pip install "ansible>=${ANSIBLE_VERSION},<$(echo "${ANSIBLE_VERSION}+0.1" | bc)"; \
+			pip install --no-cache-dir "ansible>=${ANSIBLE_VERSION},<$(echo "${ANSIBLE_VERSION}+0.1" | bc)"; \
 		fi \
 	&& apt-get remove -f -y --purge --auto-remove build-essential bc \
 	&& apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN set -x \
 			pip install --no-cache-dir "ansible>=${ANSIBLE_VERSION},<$(echo "${ANSIBLE_VERSION}+0.1" | bc)"; \
 		fi \
 	&& pip install --no-cache-dir \
+		jmespath \
 		pyaml \
 	&& apt-get remove -f -y --purge --auto-remove build-essential bc \
 	&& apt-get clean \

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -3,7 +3,28 @@ FROM flaconi/ansible:${ANSIBLE_VERSION}
 
 LABEL maintainer="devops@flaconi.de"
 
-RUN pip install --no-cache-dir \
-      boto \
-      boto3 \
-      botocore
+RUN set -x \
+	&& DEBIAN_FRONTEND=noninteractive \
+	&& apt-get update -y \
+	&& apt-get install --no-install-recommends --no-install-suggests -y \
+		curl \
+	&& apt-get remove -f -y --purge --auto-remove \
+	&& apt-get clean \
+	&& apt-get autoremove -y \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache
+
+RUN set -x \
+	&& pip install --no-cache-dir \
+		awscli \
+		boto \
+		boto3 \
+		botocore \
+		openshift
+
+RUN set -x \
+	&& curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+	&& chmod +x /usr/local/bin/kubectl
+
+RUN set -x \
+	&& curl -Lo /usr/local/bin/kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64 \
+	&& chmod +x /usr/local/bin/kops

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -15,6 +15,7 @@ RUN set -x \
 
 RUN set -x \
 	&& pip install --no-cache-dir \
+		aws \
 		awscli \
 		boto \
 		boto3 \

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ help:
 	@printf "%s\n"   "make build-24:        Build Ansible 2.4 Docker image"
 	@printf "%s\n"   "make build-25:        Build Ansible 2.5 Docker image"
 	@printf "%s\n\n" "make build-26:        Build Ansible 2.6 Docker image"
+	@printf "%s\n\n" "make build-27:        Build Ansible 2.7 Docker image"
 	@printf "%s\n"   "make test-all:        Test all images (see below)"
 	@printf "%s\n"   "make test-latest:     Test Ansible latest Docker image"
 	@printf "%s\n"   "make test-23:         Test Ansible 2.3 Docker image"
 	@printf "%s\n"   "make test-24:         Test Ansible 2.4 Docker image"
 	@printf "%s\n"   "make test-25:         Test Ansible 2.5 Docker image"
 	@printf "%s\n\n" "make test-26:         Test Ansible 2.6 Docker image"
+	@printf "%s\n\n" "make test-27:         Test Ansible 2.7 Docker image"
 
 
 ###
@@ -28,7 +30,7 @@ update-base:
 ###
 ### Build all
 ###
-build-all: build-latest build-latest-aws build-23 build-23-aws build-24 build-24-aws build-25 build-25-aws build-26 build-26-aws
+build-all: build-latest build-latest-aws build-23 build-23-aws build-24 build-24-aws build-25 build-25-aws build-26 build-26-aws build-27 build-27-aws
 
 
 ###
@@ -64,11 +66,17 @@ build-26: update-base
 build-26-aws: build-26
 	docker build --build-arg ANSIBLE_VERSION=2.6 -t flaconi/ansible:2.6-aws -f ./Dockerfile.aws .
 
+build-27: update-base
+	docker build --build-arg ANSIBLE_VERSION=2.7 -t flaconi/ansible:2.7 .
+
+build-27-aws: build-27
+	docker build --build-arg ANSIBLE_VERSION=2.7 -t flaconi/ansible:2.7-aws -f ./Dockerfile.aws .
+
 
 ###
 ### Test all
 ###
-test-all: test-latest test-latest-aws test-23 test-23-aws test-24 test-24-aws test-25 test-25-aws test-26 test-26-aws
+test-all: test-latest test-latest-aws test-23 test-23-aws test-24 test-24-aws test-25 test-25-aws test-26 test-26-aws test-27 test-27-aws
 
 
 ###
@@ -82,6 +90,9 @@ test-latest:
 test-latest-aws:
 	docker images | grep 'flaconi/ansible' | grep 'latest-aws'
 	docker run --rm flaconi/ansible:latest-aws ansible --version | grep "$(LATEST)"
+	docker run --rm flaconi/ansible:latest-aws aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
+	docker run --rm flaconi/ansible:latest-aws kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
+	docker run --rm flaconi/ansible:latest-aws kops version | grep -E '^Version\s+[.0-9]+'
 
 test-23:
 	docker images | grep 'flaconi/ansible' | grep -E '2.3\s'
@@ -90,6 +101,9 @@ test-23:
 test-23-aws:
 	docker images | grep 'flaconi/ansible' | grep '2.3-aws'
 	docker run --rm flaconi/ansible:2.3-aws ansible --version | grep '2.3'
+	docker run --rm flaconi/ansible:2.3-aws aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
+	docker run --rm flaconi/ansible:2.3-aws kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
+	docker run --rm flaconi/ansible:2.3-aws kops version | grep -E '^Version\s+[.0-9]+'
 
 test-24:
 	docker images | grep 'flaconi/ansible' | grep -E '2.4\s'
@@ -98,6 +112,9 @@ test-24:
 test-24-aws:
 	docker images | grep 'flaconi/ansible' | grep '2.4-aws'
 	docker run --rm flaconi/ansible:2.4-aws ansible --version | grep '2.4'
+	docker run --rm flaconi/ansible:2.4-aws aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
+	docker run --rm flaconi/ansible:2.4-aws kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
+	docker run --rm flaconi/ansible:2.4-aws kops version | grep -E '^Version\s+[.0-9]+'
 
 test-25:
 	docker images | grep 'flaconi/ansible' | grep -E '2.5\s'
@@ -106,6 +123,9 @@ test-25:
 test-25-aws:
 	docker images | grep 'flaconi/ansible' | grep '2.5-aws'
 	docker run --rm flaconi/ansible:2.5-aws ansible --version | grep '2.5'
+	docker run --rm flaconi/ansible:2.5-aws aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
+	docker run --rm flaconi/ansible:2.5-aws kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
+	docker run --rm flaconi/ansible:2.5-aws kops version | grep -E '^Version\s+[.0-9]+'
 
 test-26:
 	docker images | grep 'flaconi/ansible' | grep -E '2.6\s'
@@ -114,3 +134,17 @@ test-26:
 test-26-aws:
 	docker images | grep 'flaconi/ansible' | grep '2.6-aws'
 	docker run --rm flaconi/ansible:2.6-aws ansible --version | grep '2.6'
+	docker run --rm flaconi/ansible:2.6-aws aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
+	docker run --rm flaconi/ansible:2.6-aws kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
+	docker run --rm flaconi/ansible:2.6-aws kops version | grep -E '^Version\s+[.0-9]+'
+
+test-27:
+	docker images | grep 'flaconi/ansible' | grep -E '2.7\s'
+	docker run --rm flaconi/ansible:2.7 ansible --version | grep '2.7'
+
+test-27-aws:
+	docker images | grep 'flaconi/ansible' | grep '2.7-aws'
+	docker run --rm flaconi/ansible:2.7-aws ansible --version | grep '2.7'
+	docker run --rm flaconi/ansible:2.7-aws aws --version 2>&1 | grep -E '^aws-cli/[.0-9]+'
+	docker run --rm flaconi/ansible:2.7-aws kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
+	docker run --rm flaconi/ansible:2.7-aws kops version | grep -E '^Version\s+[.0-9]+'


### PR DESCRIPTION
# Update Ansible version and add AWS tools

## Added tools:
* aws
* awscli
* curl
* kubectl
* kops

## Added pip packages
* openshift
* jmespath

## Added tests
Againsts aws, kubectl and kops