### PR TITLE
OPS-0 Ensure to retry build pipeline on network outages to prevent CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ services:
 
 
 ###
+### Language
+###
+language: minimal
+
+
+###
 ### Env variables
 ###
 env:
@@ -32,18 +38,23 @@ env:
 ### Install requirements
 ###
 install:
-  # Get newer docker version
-  - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get update; then break; else i=$((i+1)); fi done
-  - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce; then break; else i=$((i+1)); fi done
-  - docker version
+  - retry() {
+      for ((n=0; n<10; n++)); do
+        echo "[${n}] ${*}";
+        if eval "${*}"; then
+          return 0;
+        fi;
+      done;
+      return 1;
+    }
 
 
 ###
 ### Build and test Docker images
 ###
 before_script:
-  - make build-${TAG//.}
-  - make test-${TAG//.}
+  - retry make build-${TAG//.}
+  - retry make test-${TAG//.}
 
 
 ###

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -3,7 +3,7 @@ FROM flaconi/ansible:${ANSIBLE_VERSION}
 
 LABEL maintainer="devops@flaconi.de"
 
-RUN set -x \
+RUN set -eux \
 	&& DEBIAN_FRONTEND=noninteractive \
 	&& apt-get update -y \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
@@ -13,7 +13,7 @@ RUN set -x \
 	&& apt-get autoremove -y \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache
 
-RUN set -x \
+RUN set -eux \
 	&& pip install --no-cache-dir \
 		aws \
 		awscli \
@@ -22,10 +22,14 @@ RUN set -x \
 		botocore \
 		openshift
 
-RUN set -x \
+RUN set -eux \
 	&& curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
-	&& chmod +x /usr/local/bin/kubectl
+	&& chmod +x /usr/local/bin/kubectl \
+	&& kubectl version --client --short=true 2>&1 \
+	&& kubectl version --client --short=true 2>&1 | grep -E 'v[.0-9]+'
 
-RUN set -x \
+RUN set -eux \
 	&& curl -Lo /usr/local/bin/kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64 \
-	&& chmod +x /usr/local/bin/kops
+	&& chmod +x /usr/local/bin/kops \
+	&& kops version \
+	&& kops version | grep -E '^Version\s+[.0-9]+'


### PR DESCRIPTION
### Description
This PR adds `retry` functionality to Travis CI build jobs in order to re-trigger in case of failures

### Background
The full build errors almost every second run in one or two jobs due to ssl handshake errors (network time-out) when downloading kubectl or kops. In order to mitigate this short network failure, the build job will just retry and will hopefully be lucky next time.